### PR TITLE
Deb: Add alternative dependency for debian stable

### DIFF
--- a/deb-package/DEBIAN/control
+++ b/deb-package/DEBIAN/control
@@ -3,7 +3,7 @@ Version: VERSION
 Architecture: amd64
 Maintainer: Raphael Lehmann <raphael+openocdbuild@rleh.de>
 Installed-Size: 5790
-Depends: libc6 (>= 2.15), libftdi1-2 (>= 1.2), libhidapi-hidraw0 (>= 0.8.0~rc1+git20140201.3a66d4e+dfsg), libjaylink0, libjim0.79 (>= 0.73), libusb-0.1-4 (>= 2:0.1.12), libusb-1.0-0 (>= 2:1.0.16)
+Depends: libc6 (>= 2.15), libftdi1-2 (>= 1.2), libhidapi-hidraw0 (>= 0.8.0~rc1+git20140201.3a66d4e+dfsg), libjaylink0, libjim0.79 (>= 0.73) | libjim0.77 (>= 0.73), libusb-0.1-4 (>= 2:0.1.12), libusb-1.0-0 (>= 2:1.0.16)
 Section: embedded
 Priority: optional
 Homepage: http://openocd.sourceforge.net/


### PR DESCRIPTION
Sadly the debian/ubuntu packages encode some version number in their name,
since openocd seems to require atleast 0.73,
it should be fine to depend either one of them:
- libjim0.79 (Ub20.04, Debian experimental)
- libjim0.77 (Ub18.04, Debian buster/stable)

(when are new builds by the bot available on branches or PRs?)